### PR TITLE
Handle tags that include underscores in editing mode.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -90,11 +90,14 @@ class editorPlugin implements PluginValue {
 							}
 						}
 
-						const text = view.state.sliceDoc(node.from, node.to);
+						// Step backwards to find the start of the tag.
+						let { from } = node;
+						while (view.state.sliceDoc(from - 1, from) !== "#") from--;
+						const text = view.state.sliceDoc(from, node.to);
 
 						builder.add(
 							// To include the "#".
-							node.from - 1,
+							from - 1,
 							node.to,
 							Decoration.replace({
 								widget: new TagWidget(text, false),


### PR DESCRIPTION
Fixes tag detection for tags containing underscores by properly identifying the tag start position.

Closes #11

![{3ACF937E-1857-4F29-BD39-5A4410E61F1E}](https://github.com/user-attachments/assets/75ed4515-be60-4557-a77c-b4991ae2dda5)
